### PR TITLE
Adding custom kmeans example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ tool to generate a contributors graphic below.
 
 ## TODO
 
-- flush out case without a label to learn (try kmeans)
 - should we have a server generic client to plug in here instead?
-- add some basic set of frontend views?
-- add frontend views - some kind of sockets?
+- add some basic set of frontend views? some kind of sockets?
 - work on same thing with FastAPI?

--- a/django_river_ml/client.py
+++ b/django_river_ml/client.py
@@ -219,7 +219,11 @@ class RiverClient:
         model = self.db[f"models/{model_name}"]
 
         try:
-            model.learn_one(x=copy.deepcopy(features), y=ground_truth)
+            # unsupervised
+            if not ground_truth:
+                model = model.learn_one(x=copy.deepcopy(features))
+            else:
+                model.learn_one(x=copy.deepcopy(features), y=ground_truth)
         except Exception as e:
             return False, repr(e)
 
@@ -298,8 +302,9 @@ class RiverClient:
         # We can fallback to secondary prediction functions
         # given that models can be used in different contexts
         for p, pred_func_name in enumerate(flavor.pred_funcs):
-            pred_func = getattr(model, pred_func_name)
             try:
+                pred_func = getattr(model, pred_func_name)
+
                 # Always copy because the model might modify the features in-place
                 prediction = pred_func(x=copy.deepcopy(features))
 

--- a/django_river_ml/flavors.py
+++ b/django_river_ml/flavors.py
@@ -9,7 +9,13 @@ from river import metrics
 
 
 def all_models():
-    return [RegressionFlavor, BinaryFlavor, MultiClassFlavor, CustomFlavor]
+    return [
+        RegressionFlavor,
+        BinaryFlavor,
+        MultiClassFlavor,
+        ClusterFlavor,
+        CustomFlavor,
+    ]
 
 
 def check(model, flavor_name):

--- a/django_river_ml/settings.py
+++ b/django_river_ml/settings.py
@@ -65,8 +65,6 @@ DEFAULTS = {
     # Shelve and jwt keys (will be generated if not found)
     "SHELVE_SECRET_KEY": None,
     "JWT_SECRET_KEY": None,
-    # Lookup of custom modules
-    "CUSTOM_MODELS": {},
 }
 
 # The user can define a section for django_river_ml in settings

--- a/django_river_ml/settings.py
+++ b/django_river_ml/settings.py
@@ -3,6 +3,7 @@ from django.conf import settings
 import logging
 import uuid
 import os
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -21,9 +22,6 @@ authenticated_views = [
 
 
 timed_views = ["django_river_ml.views.learn.view", "django_river_ml.views.predict.view"]
-
-# TODO do we need this?
-authenticated_prefixes = ["/api/model/"]
 
 # Defaults for models and storage
 
@@ -67,13 +65,15 @@ DEFAULTS = {
     # Shelve and jwt keys (will be generated if not found)
     "SHELVE_SECRET_KEY": None,
     "JWT_SECRET_KEY": None,
+    # Lookup of custom modules
+    "CUSTOM_MODELS": {},
 }
 
 # The user can define a section for django_river_ml in settings
 CACHES = getattr(settings, "CACHES", [])
 MIDDLEWARE = getattr(settings, "MIDDLEWARE", [])
 
-ml = getattr(settings, "django_river_ml", DEFAULTS)
+ml = getattr(settings, "DJANGO_RIVER_ML", DEFAULTS)
 
 # Add middleware to calculate times and stats
 timer_middleware = "django_river_ml.middleware.timer_middleware"

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -151,19 +151,14 @@ Custom Models
 ^^^^^^^^^^^^^
 
 Django River ML has support for custom models, where a custom model is one you've defined in your application
-to use with river. In order for this to work, you should define the ``CUSTOM_MODELS`` dictionary in settings:
+to use with river. In order for this to work, you will need to define your model somewhere
+in your app so it is importable across Django apps (e.g., and when Django River ML tries to unpickle
+a model object of that type, it will be found). If needed, we can further define a custom
+set of classes in settings that can be looked for via importlib, however the simple
+approch to define it in your app or otherwise install a module that makes it importable is
+suggested.
 
-.. code-block:: python
-
-   DJANGO_RIVER_ML = {
-       ...
-       "CUSTOM_MODELS": {"tests.custom.VariableVocabKMeans": os.path.join(APP_DIR, "custom.py")}
-      ...
-   }
-   
-In the example above, our app is called "tests" and there is a file ``custom.py`` there.
-Since this is our application, Django River ML will be able to import the class to un-pickle it with
-dill. Custom models currently support stats but not metrics, and metrics could be supported
+Custom models currently support stats but not metrics, and metrics could be supported
 if we think about how to go about it. the ``CustomModel`` flavor is designed to be mostly
 forgiving to allow you to choose any prediction function you might have, and we can extend this
 if needed.
@@ -235,6 +230,8 @@ In another terminal, you can then run a sample script:
     $ python examples/regression/run.py
     $ python examples/binary/run.py
     $ python examples/multiclass/run.py
+    $ python examples/cluster/run.py
+    $ python examples/custom/run.py
 
 
 Testing

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -110,10 +110,6 @@ The following additonal settings are available to set in your ``settings.py``:
      - None (and then is set to ``os.path.join(APP_DIR, "cache")``)
      - The cache directory for tokens, recommended to set a custom ``APP_DIR`` and it will be a sub-directory ``cache`` there
      - /opt/cache
-   * - ``CUSTOM_MODELS``
-     - unset (empty dict)
-     - Define a lookup (dict) of custom models, where the key is the import path, and value is the full filename path
-     - ``{"tests.custom.VariableVocabKMeans": os.path.join(APP_DIR, "custom.py")}``
    * - ``GENERATE_IDENTIFIERS``
      - True
      - Always generate identifiers for predictions. If False, you can still provide an identifier to the predict endpoint to use.

--- a/docs/getting_started/user-guide.rst
+++ b/docs/getting_started/user-guide.rst
@@ -110,6 +110,10 @@ The following additonal settings are available to set in your ``settings.py``:
      - None (and then is set to ``os.path.join(APP_DIR, "cache")``)
      - The cache directory for tokens, recommended to set a custom ``APP_DIR`` and it will be a sub-directory ``cache`` there
      - /opt/cache
+   * - ``CUSTOM_MODELS``
+     - unset (empty dict)
+     - Define a lookup (dict) of custom models, where the key is the import path, and value is the full filename path
+     - ``{"tests.custom.VariableVocabKMeans": os.path.join(APP_DIR, "custom.py")}``
    * - ``GENERATE_IDENTIFIERS``
      - True
      - Always generate identifiers for predictions. If False, you can still provide an identifier to the predict endpoint to use.
@@ -142,6 +146,28 @@ The following additonal settings are available to set in your ``settings.py``:
 
 For more advanced settings like customizing the endpoints with authentication, see
 the `settings.py <https://github.com/vsoch/django-river-ml/blob/main/django_river_ml/settings.py>`_ in the application.
+
+Custom Models
+^^^^^^^^^^^^^
+
+Django River ML has support for custom models, where a custom model is one you've defined in your application
+to use with river. In order for this to work, you should define the ``CUSTOM_MODELS`` dictionary in settings:
+
+.. code-block:: python
+
+   DJANGO_RIVER_ML = {
+       ...
+       "CUSTOM_MODELS": {"tests.custom.VariableVocabKMeans": os.path.join(APP_DIR, "custom.py")}
+      ...
+   }
+   
+In the example above, our app is called "tests" and there is a file ``custom.py`` there.
+Since this is our application, Django River ML will be able to import the class to un-pickle it with
+dill. Custom models currently support stats but not metrics, and metrics could be supported
+if we think about how to go about it. the ``CustomModel`` flavor is designed to be mostly
+forgiving to allow you to choose any prediction function you might have, and we can extend this
+if needed.
+
 
 Authentication
 --------------

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,5 +19,6 @@ $ python manage.py runserver
  - [regression](regression)
  - [binary](binary)
  - [multiclass](multiclass)
+ - [cluster](cluster)
  - [custom](custom): currently is an example for a custom model (kmeans) 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,3 +19,5 @@ $ python manage.py runserver
  - [regression](regression)
  - [binary](binary)
  - [multiclass](multiclass)
+ - [custom](custom): currently is an example for a custom model (kmeans) 
+

--- a/examples/cluster/requirements.txt
+++ b/examples/cluster/requirements.txt
@@ -1,0 +1,1 @@
+riverapi

--- a/examples/cluster/run.py
+++ b/examples/cluster/run.py
@@ -1,0 +1,47 @@
+from riverapi.main import Client
+
+from river import cluster, stream
+
+
+def main():
+
+    # This is the default, just to show how to customize
+    cli = Client("http://localhost:8000")
+
+    # Upload a model
+    X = [[1, 2], [1, 4], [1, 0], [4, 2], [4, 4], [4, 0]]
+
+    model = cluster.KMeans(n_clusters=2, halflife=0.4, sigma=3, seed=0)
+
+    model_name = cli.upload_model(model, "cluster")
+    print("Created model %s" % model_name)
+
+    for i, (x, _) in enumerate(stream.iter_array(X)):
+        res = cli.learn(model_name, x=x)
+
+    # Get the model (this is a json representation)
+    model_json = cli.get_model_json(model_name)
+
+    # Saves to model-name>.pkl in pwd unless you provide a second arg, dest
+    # cli.download_model(model_name)
+
+    # Make predictions
+    for i, (x, _) in enumerate(stream.iter_array(X)):
+        res = cli.predict(model_name, x=x)
+        print(res)
+
+    # Note that cluster models currently don't have metrics
+    # If you are interested in adding this please open an issue to discuss!
+
+    # Get stats for the model
+    stats = cli.stats(model_name)
+
+    # Get all models
+    print(cli.models())
+
+    # Delete the model to cleanup
+    cli.delete_model(model_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/custom/requirements.txt
+++ b/examples/custom/requirements.txt
@@ -1,0 +1,1 @@
+riverapi

--- a/examples/custom/run.py
+++ b/examples/custom/run.py
@@ -1,0 +1,63 @@
+from riverapi.main import Client
+
+import os
+import sys
+
+# This adds the root of the repository so tests is importable
+# This is the same path seen by our server (important)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from tests.custom import iter_counts, VariableVocabKMeans
+
+def main():
+
+    # This is the default, just to show how to customize
+    cli = Client("http://localhost:8000")
+
+    # Upload a model
+
+    # Instead of numbers, we provide vectors of tokens (or strings)
+    X = [
+       ["one", "two"],
+       ["one", "four"],
+       ["one", "zero"],
+       ["five", "six"],
+       ["seven", "eight"],
+       ["nine", "nine"]
+    ]
+
+    model = VariableVocabKMeans(n_clusters=2, halflife=0.4, sigma=3, seed=0)
+
+    model_name = cli.upload_model(model, "custom")
+    print("Created model %s" % model_name)
+
+    for i, vocab in enumerate(iter_counts(X)):
+        print(f"Learning from {vocab}")
+        cli.learn(model_name, x=vocab)
+
+    # Get the model (this is a json representation)
+    model_json = cli.get_model_json(model_name)
+
+    # Saves to model-name>.pkl in pwd unless you provide a second arg, dest
+    # cli.download_model(model_name)
+
+    # Make predictions
+    for i, vocab in enumerate(iter_counts(X)):
+        res = cli.predict(model_name, x=vocab)
+        print(res)
+
+    # Note that custom models currently don't support metrics.
+    # If you are interested in adding this please open an issue to discuss!
+
+    # Get stats for the model
+    stats = cli.stats(model_name)
+
+    # Get all models
+    print(cli.models())
+
+    # Delete the model to cleanup
+    cli.delete_model(model_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/custom/run.py
+++ b/examples/custom/run.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tests.custom import iter_counts, VariableVocabKMeans
 
+
 def main():
 
     # This is the default, just to show how to customize
@@ -18,12 +19,12 @@ def main():
 
     # Instead of numbers, we provide vectors of tokens (or strings)
     X = [
-       ["one", "two"],
-       ["one", "four"],
-       ["one", "zero"],
-       ["five", "six"],
-       ["seven", "eight"],
-       ["nine", "nine"]
+        ["one", "two"],
+        ["one", "four"],
+        ["one", "zero"],
+        ["five", "six"],
+        ["seven", "eight"],
+        ["nine", "nine"],
     ]
 
     model = VariableVocabKMeans(n_clusters=2, halflife=0.4, sigma=3, seed=0)

--- a/tests/custom.py
+++ b/tests/custom.py
@@ -1,0 +1,213 @@
+import collections
+import functools
+import random
+from typing import Dict, List
+
+from river import base, utils
+
+
+def iter_counts(X: List[List[str]]):
+    """
+    Given lists of words, return vocabularies with counts. This is useful
+    for the VariableVocabKMeans model that expects this input.
+
+    Parameters
+    ----------
+    X
+        A list of lists of words (str)
+
+    Example
+    -------
+
+    >>> X = [
+    ...    ["one", "two"],
+    ...    ["one", "four"],
+    ...    ["one", "zero"],
+    ...    ["four", "two"],
+    ...    ["four", "four"],
+    ...    ["four", "zero"]
+    ... ]
+
+    >>> for i, vocab in enumerate(stream.iter_counts(X)):
+    ...    print(vocab)
+
+    ... {'one': 1, 'two': 1}
+    ... {'one': 1, 'four': 1}
+    ... {'one': 1, 'zero': 1}
+    ... {'four': 1, 'two': 1}
+    ... {'four': 2}
+    ... {'four': 1, 'zero': 1}
+    """
+    # Convert to counts (vocabulary)
+    counts = []
+    for words in X:
+        vocab = {}
+        for word in words:
+            if word not in vocab:
+                vocab[word] = 0
+            vocab[word] += 1
+        counts.append(vocab)
+    return counts
+
+
+class VariableVocabKMeans(base.Clusterer):
+    """Variable Vocabulary KMeans
+
+    Instead of requiring a fixed set of features that are numerical, this version
+    of Kmeans:
+
+    1. Allows for providing a vocabulary (string variables) that are stored with the model
+    2. Allows adding new words to the vocabulary.
+
+    When we encounter a new word, given that it isn't in the vocabulary this means that
+    we've never seen it before (and we know that the cluster centers can be given a  0
+    value. This is an example of a custom model for the django-river-ml server.
+
+    Parameters
+    ----------
+    n_clusters
+        Maximum number of clusters to assign.
+    halflife
+        Amount by which to move the cluster centers, a reasonable value if between 0 and 1.
+    mu
+        Mean of the normal distribution used to instantiate cluster positions.
+    sigma
+        Standard deviation of the normal distribution used to instantiate cluster positions.
+    p
+        Power parameter for the Minkowski metric. When `p=1`, this corresponds to the Manhattan
+        distance, while `p=2` corresponds to the Euclidean distance.
+    seed
+        Random seed used for generating initial centroid positions.
+
+    Attributes
+    ----------
+    vocab: dict
+        Vocabulary that matches str tokens to their index in each center vector
+    centers : dict
+        Central positions of each cluster.
+
+    Examples
+    --------
+
+    >>> from river import cluster
+    >>> from river import stream
+
+    # Instead of numbers, we provide vectors of tokens (or strings)
+    >>> X = [
+    ...    ["one", "two"],
+    ...    ["one", "four"],
+    ...    ["one", "zero"],
+    ...    ["five", "six"],
+    ...    ["seven", "eight"],
+    ...    ["nine", "nine"]
+    ]
+
+    >>> model = cluster.VariableVocabKMeans(n_clusters=2, halflife=0.4, sigma=3, seed=0)
+
+    >>> for i, vocab in enumerate(stream.iter_counts(X)):
+    ...     model = model.learn_one(vocab)
+    ...     center = model.predict_one(vocab)
+    ...     print(f'{vocab} is assigned to cluster {center}')
+    ...     # Get coord/value for each word
+    ...     model.get_center_vocab(center)
+    ...
+
+    ... {'one': 1, 'two': 1} is assigned to cluster 0
+    ... {'one': 1, 'four': 1} is assigned to cluster 0
+    ... {'one': 1, 'zero': 1} is assigned to cluster 0
+    ... {'five': 1, 'six': 1} is assigned to cluster 1
+    ... {'seven': 1, 'eight': 1} is assigned to cluster 2
+    ... {'nine': 2} is assigned to cluster 3
+    """
+
+    def __init__(
+        self, n_clusters=5, halflife=0.5, mu=0, sigma=1, p=2, seed: int = None
+    ):
+        self.n_clusters = n_clusters
+        self.halflife = halflife
+        self.mu = mu
+        self.sigma = sigma
+        self.p = p
+        self.seed = seed
+        self._rng = random.Random(seed)
+        rand_gauss = functools.partial(self._rng.gauss, self.mu, self.sigma)
+
+        # Vocab is a lookup between vocab items and vector indices
+        self.vocab = {}
+
+        # Current index into vocab array
+        self.index = 0
+        self.centers = {
+            i: collections.defaultdict(rand_gauss) for i in range(n_clusters)
+        }  # type: ignore
+
+    def get_center_vocab(self, center: int):
+        """
+        Given the id of a centroid, get the vocab and weights / counts for it.
+        """
+        # We need to be able to look up words based on index
+        lookup = {idx: word for word, idx in self.vocab.items()}
+        return {lookup[x]: count for x, count in self.centers[center].items()}
+
+    def learn_predict_one(self, x: Dict[str, int]):
+        """Equivalent to `k_means.learn_one(x).predict_one(x)`, but faster."""
+
+        # Find the cluster with the closest center
+        # Don't update vocab yet because it doesn't matter if we haven't
+        # seen a token - it will return a count of 0.
+        closest = self.predict_one(x)
+
+        # Ensure centers have all features for future learning
+        self.update_vocab(x)
+
+        # Move the cluster's center (ONLY the one closest to!)
+        # By this point all words are added to the vocabulary
+        for word, count in x.items():
+            xx = {self.vocab[word]: count}
+            for i, xi in xx.items():
+                self.centers[closest][i] += self.halflife * (
+                    xi - self.centers[closest][i]
+                )
+
+        return closest
+
+    def learn_one(self, x, y=None):
+        self.learn_predict_one(x)
+        return self
+
+    def update_vocab(self, x: Dict[str, int]):
+        """
+        Given a vector of features, ensure we have each in our vocab
+        """
+        # We can do one dict update per new word
+        updates = {}
+        for word, count in x.items():
+            if word not in self.vocab:
+                self.vocab[word] = self.index
+
+                # The word has never been seen by any previous centroid
+                updates[self.index] = 0
+                self.index += 1
+
+        # This is akin to appending a new dimension to each vector
+        for _, center in self.centers.items():
+            center.update(updates)
+
+    def predict_one(self, x: List[List[str]]):
+
+        # Ensure we provide a lookup between features (vocab indices)
+        # This should only include words we have seen before
+        xx = {
+            self.vocab.get(word): count
+            for word, count in x.items()
+            if word in self.vocab
+        }
+
+        def get_distance(c):
+            return utils.math.minkowski_distance(a=self.centers[c], b=xx, p=self.p)
+
+        return min(self.centers, key=get_distance)
+
+    @classmethod
+    def _unit_test_params(cls):
+        yield {"n_clusters": 5}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,10 +18,6 @@ DJANGO_RIVER_ML = {
     # Shelve and jwt keys (will be generated if not found)
     "SHELVE_SECRET_KEY": "pancakes",
     "JWT_SECRET_KEY": "pancakes",
-    # import tests.custom.VariableVocabMeans as custom model type
-    "CUSTOM_MODELS": {
-        "tests.custom.VariableVocabKMeans": os.path.join(APP_DIR, "custom.py")
-    },
 }
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,23 +1,28 @@
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_DIR = os.path.dirname(os.path.abspath(__file__))
+BASE_DIR = os.path.dirname(APP_DIR)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
-# Django River ML Settings.
+# Django River ML Example Settings.
 
-django_river_ml = {
+DJANGO_RIVER_ML = {
+    # Url base prefix
+    "URL_PREFIX": "api",
     "STORAGE_BACKEND": "shelve",
     "APP_DIR": BASE_DIR,
     "DISABLE_AUTHENTICATION": True,
-    "MODEL_FLAVOR": "regression",
     # Shelve and jwt keys (will be generated if not found)
     "SHELVE_SECRET_KEY": "pancakes",
     "JWT_SECRET_KEY": "pancakes",
+    # import tests.custom.VariableVocabMeans as custom model type
+    "CUSTOM_MODELS": {
+        "tests.custom.VariableVocabKMeans": os.path.join(APP_DIR, "custom.py")
+    },
 }
-
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "@=n*^a0q4($45&jl5x+8_f_1yt5w+brp^&r5tk@5_yt-4=h27f"
@@ -82,21 +87,6 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "db-test.sqlite3"),
     }
-}
-
-# Django OCI Example (with defaults_
-
-DJANGO_OCI = {
-    # Url base prefix
-    "URL_PREFIX": "v2",
-    # Version of distribution spec
-    "SPEC_VERSION": "1",
-    # Repository permissions
-    "PRIVATE_ONLY": False,
-    # Disabled authentication, boolean triggered by environment for testing
-    "DISABLE_AUTHENTICATION": os.environ.get("DISABLE_AUTHENTICATION") is not None,
-    # "secret" for jwt decoding, hard coded for tests here. Likely you'd want to set in enviroment
-    "JWT_SERVER_SECRET": "c4978944-8ea4-41f2-ac55-e38dcc09cff4'",
 }
 
 # Password validation

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,7 +101,7 @@ class APIBaseTests(APITestCase):
         assert stats["learn"]["n_calls"] == 6
 
         # Delete the model to cleanup
-        self.clint.delete_model(model_name)
+        self.client.delete_model(model_name)
 
     def test_regression(self):
         """


### PR DESCRIPTION
This is a prototype that will allow a user to define a custom model type (typically within their app) to be used on the server. Actually, given that the module can be imported this is fairly trivial to do! I set it up to require them to register it via settings, but i practice didn't actually need that. I'm thinking it still might make sense to keep this requirement in the case that the module is not seen by the application and needs a custom import (via importlib).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>